### PR TITLE
Changed match parameter to development (aka testflight)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,8 @@ lib/generated_plugin_registrant.dart
 /ios/**/Icon?
 /ios/**/Pods/
 /ios/**/.symlinks/
+/ios/**/.bundle
+/ios/**/vendor
 /ios/**/profile
 /ios/**/xcuserdata
 /ios/.generated/

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -20,7 +20,7 @@ platform :ios do
   lane :beta do
     match(
       git_url: "git@github.com:jhass/insporation-certificates.git",
-      type: "appstore",
+      type: "development",
       readonly: true
     )
     increment_build_number(build_number: ENV["GITHUB_RUN_NUMBER"] || "1")


### PR DESCRIPTION
It's more or less a try. 
"Appstore" is not the beta build, but the release build.