### PR TITLE
Simplified error messages on sign in.

### DIFF
--- a/android/app/src/main/kotlin/jhass/eu/insporation/AppAuthHandler.kt
+++ b/android/app/src/main/kotlin/jhass/eu/insporation/AppAuthHandler.kt
@@ -114,7 +114,7 @@ private class CallHandler(private val context: Context,
             continuation.resume(Tokens(accessToken!!, idToken))
           } else {
             Log.d("AppAuth", "Failed to fetch access token for ${currentSession.userId}: ${exception?.fullMessage()}")
-            continuation.resumeWithException(CallError("failed_token_fetch", "Failed to obtain access token", exception))
+            continuation.resumeWithException(CallError("failed_token_fetch", "Failed to obtain access token"))
           }
         }
       }
@@ -200,7 +200,7 @@ private class CallHandler(private val context: Context,
 
     if (result.exception != null) {
       Log.d("AppAuth", "Failed to authorize $userId: ${result.exception.fullMessage()}")
-      throw CallError("failed_authorize", "Failed to authorize user", result.exception)
+      throw CallError("failed_authorize", "Failed to authorize user")
     }
 
     try {
@@ -226,7 +226,7 @@ private class CallHandler(private val context: Context,
 
     if (result.exception != null) {
       Log.d("AppAuth", "Failed to exchange authorization for ${session.userId} for tokens: ${result.exception.fullMessage()}")
-      throw CallError("failed_authorize", "Failed to exchange authorization token", result.exception)
+      throw CallError("failed_authorize", "Failed to exchange authorization token")
     }
 
     Log.d("AppAuth", "Successfully exchanged token for authorization for ${session.userId}")
@@ -244,7 +244,7 @@ private class CallHandler(private val context: Context,
           continuation.resume(serviceConfig)
         } else {
           Log.d("AppAuth", "Failed to discover service config for $host: ${exception?.fullMessage()}")
-          continuation.resumeWithException(CallError("failed_discovery", "Failed to discover service config", exception))
+          continuation.resumeWithException(CallError("failed_discovery", "Failed to discover service config"))
         }
       }
     }
@@ -261,7 +261,7 @@ private class CallHandler(private val context: Context,
           continuation.resume(response)
         } else {
           Log.d("AppAuth", "Failed to register to $host: ${exception?.fullMessage()}")
-          continuation.resumeWithException(CallError("failed_register", "Failed to register", exception))
+          continuation.resumeWithException(CallError("failed_register", "Failed to register"))
         }
       }
     }

--- a/android/app/src/main/kotlin/jhass/eu/insporation/AppAuthHandler.kt
+++ b/android/app/src/main/kotlin/jhass/eu/insporation/AppAuthHandler.kt
@@ -21,7 +21,7 @@ import kotlin.coroutines.suspendCoroutine
 private const val APP_AUTH_CHANNEL = "insporation/appauth"
 private const val APP_AUTH_SESSION_CHANNEL = "insporation/appauth_authorization_events"
 private val APP_AUTH_REDIRECT_URI : Uri = Uri.parse("eu.jhass.insporation://callback")
-private const val TIMEOUT = 60000L
+private const val TIMEOUT = 6_000L // In Milliseconds
 
 typealias OnLaunchAuthorizationIntent = (intent: Intent, data: String) -> Unit
 

--- a/android/app/src/main/kotlin/jhass/eu/insporation/AppAuthHandler.kt
+++ b/android/app/src/main/kotlin/jhass/eu/insporation/AppAuthHandler.kt
@@ -244,7 +244,7 @@ private class CallHandler(private val context: Context,
           continuation.resume(serviceConfig)
         } else {
           Log.d("AppAuth", "Failed to discover service config for $host: ${exception?.fullMessage()}")
-          continuation.resumeWithException(CallError("failed_register", "Failed to fetch service config", exception))
+          continuation.resumeWithException(CallError("failed_discovery", "Failed to discover service config", exception))
         }
       }
     }

--- a/ios/Runner/AppAuthHandler.swift
+++ b/ios/Runner/AppAuthHandler.swift
@@ -12,6 +12,10 @@ import os.log
 
 typealias PostRegistrationCallback = (_ configuration: OIDServiceConfiguration?, _ registrationResponse: OIDRegistrationResponse?) -> Void
 
+struct ErrorMessage {
+    var code: String
+    var message: String
+}
 
 class AppAuthHandler {
     
@@ -25,31 +29,53 @@ class AppAuthHandler {
     let authMethodChannel: FlutterMethodChannel
     var currentSession: Session?
     
+    private let TIMEOUT_IN_SECONDS = 6.0 // Wait a relative short ammout of time.
+    
     private var completionHandler: [(_ tokens:Tokens) -> Void] = []
-    private var errorHandler: [(_ errorMessage:String) -> Void] = []
+    private var errorHandler: [(_ code: String, _ errorMessage:String) -> Void] = []
+    
+    private let FAILED_TIMEOUT = "timeout"
+    private let FAILED_TOKEN_FETCH = "failed_token_fetch"
+    private let FAILED_AUTHORIZE = "failed_authorize"
+    private let FAILED_REGISTER = "failed_register"
+    private let FAILED_DISCOVERY = "failed_discovery" // Is the first call on new or unknown services, if this fails, service is not available or not the right API Version
+    
+    private let RUNTIME_ERROR = "runtime_error" // Not fixable by user
     
     init(methodChannel: FlutterMethodChannel, controller: UIViewController) {
         self.authMethodChannel = methodChannel
         self.controller = controller
         os_log("Init App Auth Handler")
+        predefineURLSession()
     }
     
+// Set some custom configurations for authorization sessions
+    private func predefineURLSession() {
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.timeoutIntervalForResource = TIMEOUT_IN_SECONDS
+        let session = URLSession(configuration: sessionConfig)
+        OIDURLSessionProvider.setSession(session)
+    }
+    
+    
+    // Calls all stored handler
     private func invokeCompletionHandler(tokens: Tokens) {
         while !self.completionHandler.isEmpty {
             self.completionHandler.removeFirst()(tokens)
         }
     }
     
-    private func invokeErrorHandler(errorMessage: String) {
+    // Calls all stored handler
+    private func invokeErrorHandler(code: String, errorMessage: String) {
         while !self.errorHandler.isEmpty {
-            self.errorHandler.removeFirst()(errorMessage)
+            self.errorHandler.removeFirst()(code, errorMessage)
         }
     }
     
     /**
      Gets a token from auth
      */
-    func getAccessTokens(_ session: Session, completionHandler: @escaping (Tokens) -> Void, errorHandler:@escaping (String) -> Void) {
+    func getAccessTokens(_ session: Session, completionHandler: @escaping (Tokens) -> Void, errorHandler: @escaping (String, String) -> Void) {
         self.currentSession = session
         
         self.completionHandler.append(completionHandler)
@@ -62,7 +88,7 @@ class AppAuthHandler {
             
         } else {
             os_log("State was set previously, refreshing token from existing state")
-            // A textual state was set, recover laste stored State Obejct
+            // A textual state was set, recover latest stored State Object
             recoverToken()
         }
     }
@@ -70,7 +96,7 @@ class AppAuthHandler {
     func recoverToken() {
         guard let session = self.currentSession else {
             os_log("Error in getting last session")
-            self.errorHandler.first?("Error in getting last session")
+            self.errorHandler.first?(FAILED_TOKEN_FETCH, "Internal error in getting last session")
             return
         }
         
@@ -83,7 +109,7 @@ class AppAuthHandler {
             }
             
             guard let tokenResponse = authState.lastTokenResponse else {
-                self.invokeErrorHandler(errorMessage: "No token received")
+                self.invokeErrorHandler(code: FAILED_TOKEN_FETCH, errorMessage: "No token received")
                 return
             }
             
@@ -91,7 +117,7 @@ class AppAuthHandler {
             authState.performAction { (accessToken, idToken, error) in
                 
                 if let error = error {
-                    self.invokeErrorHandler(errorMessage: error.localizedDescription)
+                    self.invokeErrorHandler(code: self.FAILED_TOKEN_FETCH, errorMessage: error.localizedDescription)
                     return
                 }
                 // Got new token
@@ -108,7 +134,7 @@ class AppAuthHandler {
     func authorizeUser() {
         guard let userId = self.currentSession?.userId else {
             os_log("No userID set")
-            self.invokeErrorHandler(errorMessage: "No user ID set")
+            self.invokeErrorHandler(code: self.FAILED_AUTHORIZE, errorMessage: "No user ID set")
             return
         }
         discoverConfiguration(forUserId: userId)
@@ -117,20 +143,27 @@ class AppAuthHandler {
     func discoverConfiguration(forUserId userId: String) {
         
         let hostname = StateHandler.hostForUser(userId: userId)
-        os_log("Discovering service config for '%{public}@'", log: .default, type: .debug, hostname)
+        os_log("Discovering service config for '%{public}@'...", log: .default, type: .debug, hostname)
         
         let discoveryURL = URL(string: "https://\(hostname)")!
+        
         OIDAuthorizationService.discoverConfiguration(forIssuer: discoveryURL) { (configuration, error) in
-            
-            if let error = error {
+            // 1001: Timeout, 1003 = Hostnot found
+            if let error = error as NSError? {
+                if self.isTimeoutError(error) {
+                    os_log("The connection timed out. ")
+                    self.invokeErrorHandler(code: self.FAILED_TIMEOUT, errorMessage: "Timeout to discover service")
+                    return
+                }
+                
                 os_log("Failed to discover service config for %{public}@: %{public}@", log: .default, type: .error, hostname, error.localizedDescription)
-                self.invokeErrorHandler(errorMessage: "Failed to discover service")
+                self.invokeErrorHandler(code: self.FAILED_DISCOVERY, errorMessage: "Failed to discover service")
                 return
             }
             
             guard let configuration = configuration else {
                 os_log("Configuration Object was empty")
-                self.invokeErrorHandler(errorMessage: "Configuraton object was empty")
+                self.invokeErrorHandler(code: self.FAILED_DISCOVERY, errorMessage: "Configuraton object was empty")
                 return
             }
             
@@ -177,9 +210,16 @@ class AppAuthHandler {
         OIDAuthorizationService.perform(registrationRequest) { (response, error) in
             
             if let error = error {
+                
+                if self.isTimeoutError(error) {
+                    os_log("The connection timed out. ")
+                    self.invokeErrorHandler(code: self.RUNTIME_ERROR, errorMessage: "Timeout to register service")
+                    return
+                }
+                
                 os_log("Failed registration client %{error}@", log: .default, type: .error, error.localizedDescription)
                 self.setAuthState(nil) // Clear local store - if already stored
-                self.invokeErrorHandler(errorMessage: "Failed to register service: \(error.localizedDescription)")
+                self.invokeErrorHandler(code: self.FAILED_REGISTER, errorMessage: "Failed to register service: \(error.localizedDescription)")
                 return
             }
             
@@ -204,8 +244,8 @@ class AppAuthHandler {
     func doAuthWithAutoCodeExchange(configuration: OIDServiceConfiguration, scopes: String,  clientID: String, clientSecret: String?) {
         
         guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
-            os_log("Error accessing AppDelegate")
-            self.invokeErrorHandler(errorMessage: "Error accessing AppDelegate")
+            os_log("RuntimeError: AppDelegate not set in code.")
+            self.invokeErrorHandler(code: self.RUNTIME_ERROR, errorMessage: "AppDelegate not set in code")
             return
         }
         
@@ -227,14 +267,21 @@ class AppAuthHandler {
                                                                      "login_hint": login])
         
         // performs authentication request
-        os_log("Initiating authorization request with request: %{public}@", log: .default, type: .default,  request.debugDescription )
+        os_log("Initiating authorization request with request: '%{public}@'...", log: .default, type: .default,  request.debugDescription )
         
         appDelegate.currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request, presenting: self.controller) { authState, error in
             
             if let error = error {
+                
+                if self.isTimeoutError(error) {
+                    os_log("The connection timed out. ")
+                    self.invokeErrorHandler(code: self.RUNTIME_ERROR, errorMessage: "Timeout to authorize")
+                    return
+                }
+                
                 os_log("Authorization error: %{public}@", log:.default, type: .error,  error.localizedDescription )
                 self.setAuthState(nil)
-                self.invokeErrorHandler(errorMessage: "Authorization error: \(error.localizedDescription)")
+                self.invokeErrorHandler(code: self.FAILED_AUTHORIZE, errorMessage: "Authorization error: \(error.localizedDescription)")
                 return
             }
             
@@ -242,7 +289,7 @@ class AppAuthHandler {
                 
                 // Token setting should end waiting service
                 guard let tokenResponse = authState.lastTokenResponse else {
-                    self.invokeErrorHandler(errorMessage: "No token received")
+                    self.invokeErrorHandler(code: self.FAILED_TOKEN_FETCH, errorMessage: "No token received")
                     return
                 }
                 
@@ -256,7 +303,7 @@ class AppAuthHandler {
     }
 }
 
-/// Load / Save Chnage States
+/// Load / Save changeable states
 extension AppAuthHandler {
     
     func setAuthState(_ authState: OIDAuthState?) {
@@ -281,7 +328,7 @@ extension AppAuthHandler {
         var data: Data? = nil
         
         if let authState = state {
-            // Attention! This arhcive-Methis is marked as depricated, but recommended method
+            // Attention! This archivedData-method is marked as depricated in iOS 12.0, but recommended method
             // will not recover the OIDAuthState correctly
             data = NSKeyedArchiver.archivedData(withRootObject: authState)
         }
@@ -300,7 +347,7 @@ extension AppAuthHandler {
             return nil
         }
         
-        // Attention! This arhcive-Methis is marked as depricated, but recommended method
+        // Attention! This archivedData-method is marked as depricated, but recommended method
         // will not recover the OIDAuthState correctly
         if let authState = NSKeyedUnarchiver.unarchiveObject(with: data) as? OIDAuthState {
             self.setAuthState(authState)
@@ -312,5 +359,17 @@ extension AppAuthHandler {
     /// Stores session into Flutter system, by using state as a textual representation
     func storeSession(session: Session) {
         self.authMethodChannel.invokeMethod("storeSession", arguments: session.toDict())
+    }
+}
+
+extension AppAuthHandler {
+    
+    func isTimeoutError(_ error: Error?) -> Bool {
+        if let error = error as NSError? {
+            if let uError = error.userInfo["NSUnderlyingError"] as! NSError? {
+                return uError.code == CFNetworkErrors.cfurlErrorTimedOut.rawValue
+            }
+        }
+        return false
     }
 }

--- a/ios/Runner/AppAuthHandler.swift
+++ b/ios/Runner/AppAuthHandler.swift
@@ -328,7 +328,7 @@ extension AppAuthHandler {
         var data: Data? = nil
         
         if let authState = state {
-            // Attention! This archivedData-method is marked as depricated in iOS 12.0, but recommended method
+            // Attention! The archivedData method is marked as deprecated in iOS 12.0, but recommended method
             // will not recover the OIDAuthState correctly
             data = NSKeyedArchiver.archivedData(withRootObject: authState)
         }

--- a/ios/Runner/AppAuthHandler.swift
+++ b/ios/Runner/AppAuthHandler.swift
@@ -49,7 +49,7 @@ class AppAuthHandler {
         predefineURLSession()
     }
     
-// Set some custom configurations for authorization sessions
+    // Set some custom configurations for authorization sessions
     private func predefineURLSession() {
         let sessionConfig = URLSessionConfiguration.default
         sessionConfig.timeoutIntervalForResource = TIMEOUT_IN_SECONDS
@@ -134,7 +134,7 @@ class AppAuthHandler {
     func authorizeUser() {
         guard let userId = self.currentSession?.userId else {
             os_log("No userID set")
-            self.invokeErrorHandler(code: self.FAILED_AUTHORIZE, errorMessage: "No user ID set")
+            self.invokeErrorHandler(code: FAILED_AUTHORIZE, errorMessage: "No user ID set")
             return
         }
         discoverConfiguration(forUserId: userId)
@@ -148,7 +148,6 @@ class AppAuthHandler {
         let discoveryURL = URL(string: "https://\(hostname)")!
         
         OIDAuthorizationService.discoverConfiguration(forIssuer: discoveryURL) { (configuration, error) in
-            // 1001: Timeout, 1003 = Hostnot found
             if let error = error as NSError? {
                 if self.isTimeoutError(error) {
                     os_log("The connection timed out. ")

--- a/ios/Runner/AppAuthHandler.swift
+++ b/ios/Runner/AppAuthHandler.swift
@@ -347,7 +347,7 @@ extension AppAuthHandler {
             return nil
         }
         
-        // Attention! This archivedData-method is marked as depricated, but recommended method
+        // Attention! The archivedData method is marked as deprecated, but recommended method
         // will not recover the OIDAuthState correctly
         if let authState = NSKeyedUnarchiver.unarchiveObject(with: data) as? OIDAuthState {
             self.setAuthState(authState)

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -42,9 +42,9 @@ import os.log
                     appAuthHandler.getAccessTokens(session) { (tokens) in
                         os_log("Token: %{public}@", log: .default, type: .default,tokens.toDict())
                         result(tokens.toDict())
-                    } errorHandler : { (errorMessage) in
+                    } errorHandler : { (code, errorMessage) in
                         os_log("Error: %{public}@", log:.default, type: .error, errorMessage)
-                        result(FlutterError(code: "AppAuth", message: errorMessage, details: nil))
+                        result(FlutterError(code: code, message: errorMessage, details: nil))
                     }
                 }
             }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2020-11-05T11:42:04.863112",
+  "@@last_modified": "2020-11-07T20:31:02.788952",
   "saveButtonLabel": "Save",
   "@saveButtonLabel": {
     "description": "Label for a dialog save button",
@@ -93,6 +93,12 @@
   "errorSignInTimeout": "Timeout while trying to authenticate, are you sure your pod supports the API?",
   "@errorSignInTimeout": {
     "description": "Error message after authenticating timed out",
+    "type": "text",
+    "placeholders": {}
+  },
+  "errorInvalidAPI": "Service did not respond as expected. Is the hostname right? Does the pod run at least version 0.8?",
+  "@errorInvalidAPI": {
+    "description": "Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher",
     "type": "text",
     "placeholders": {}
   },

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2020-11-07T20:31:02.788952",
+  "@@last_modified": "2020-11-10T09:56:20.367026",
   "saveButtonLabel": "Save",
   "@saveButtonLabel": {
     "description": "Label for a dialog save button",
@@ -96,9 +96,17 @@
     "type": "text",
     "placeholders": {}
   },
-  "errorInvalidAPI": "Service did not respond as expected. Is the hostname right? Does the pod run at least version 0.8?",
-  "@errorInvalidAPI": {
-    "description": "Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher",
+  "errorAuthorizationFailed": "Could not authorize to {userId}, is it spelled correctly, is your network running and is your pod running the latest development snapshot?",
+  "@errorAuthorizationFailed": {
+    "description": "Error message after authorization with the host failed",
+    "type": "text",
+    "placeholders": {
+      "userId": {}
+    }
+  },
+  "errorUnexpectedNetworkError": "A unexpected network error occurred",
+  "@errorUnexpectedNetworkError": {
+    "description": "A unspecified network error occurred",
     "type": "text",
     "placeholders": {}
   },

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2020-11-05T11:42:04.863112",
+  "@@last_modified": "2020-11-07T20:31:02.788952",
   "saveButtonLabel": "Save",
   "@saveButtonLabel": {
     "description": "Label for a dialog save button",
@@ -93,6 +93,12 @@
   "errorSignInTimeout": "Timeout while trying to authenticate, are you sure your pod supports the API?",
   "@errorSignInTimeout": {
     "description": "Error message after authenticating timed out",
+    "type": "text",
+    "placeholders": {}
+  },
+  "errorInvalidAPI": "Service did not respond as expected. Is the hostname right? Does the pod run at least version 0.8?",
+  "@errorInvalidAPI": {
+    "description": "Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher",
     "type": "text",
     "placeholders": {}
   },

--- a/lib/l10n/intl_messages.arb
+++ b/lib/l10n/intl_messages.arb
@@ -1,5 +1,5 @@
 {
-  "@@last_modified": "2020-11-07T20:31:02.788952",
+  "@@last_modified": "2020-11-10T09:56:20.367026",
   "saveButtonLabel": "Save",
   "@saveButtonLabel": {
     "description": "Label for a dialog save button",
@@ -96,9 +96,17 @@
     "type": "text",
     "placeholders": {}
   },
-  "errorInvalidAPI": "Service did not respond as expected. Is the hostname right? Does the pod run at least version 0.8?",
-  "@errorInvalidAPI": {
-    "description": "Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher",
+  "errorAuthorizationFailed": "Could not authorize to {userId}, is it spelled correctly, is your network running and is your pod running the latest development snapshot?",
+  "@errorAuthorizationFailed": {
+    "description": "Error message after authorization with the host failed",
+    "type": "text",
+    "placeholders": {
+      "userId": {}
+    }
+  },
+  "errorUnexpectedNetworkError": "A unexpected network error occurred",
+  "@errorUnexpectedNetworkError": {
+    "description": "A unspecified network error occurred",
     "type": "text",
     "placeholders": {}
   },

--- a/lib/sign_in_page.dart
+++ b/lib/sign_in_page.dart
@@ -258,7 +258,7 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
       });
     } on InvalidAPIException {
       setState(() {
-        _lastError = l.errorSignInNoHost;
+        _lastError = l.errorInvalidAPI;
         _loading = false;
       });
     } catch (e) {

--- a/lib/sign_in_page.dart
+++ b/lib/sign_in_page.dart
@@ -31,6 +31,7 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
   final _initialFocus = FocusNode();
   var _loading = true;
   String _lastError;
+  String _lastErrorDetails;
   Future<List<Session>> _sessions;
 
   @override
@@ -120,7 +121,7 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
               ]),
             ),
           ),
-          ErrorMessage(_lastError)
+          ErrorMessage(_lastError, errorDetails: _lastErrorDetails,)
         ]),
       )),
     );
@@ -160,6 +161,7 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
     setState(() {
       _loading = true;
       _lastError = null;
+      _lastErrorDetails = null;
     });
 
     if (persistentState.wasAuthorizing) {
@@ -207,7 +209,8 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
       debugPrintStack(label: "Failed to resume session: $e", stackTrace: s);
       setState(() {
         _loading = false;
-        _lastError = e.toString();
+        _lastError =  l.errorUnexpectedNetworkError;
+        _lastErrorDetails = e.toString();
       });
     }
   }
@@ -256,14 +259,16 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
         _lastError = l.errorSignInTimeout;
         _loading = false;
       });
-    } on AuthorizationFailedException catch (e) {
+    } on AuthorizationFailedException catch (e){
       setState(() {
-        _lastError = l.errorAuthorizationFailed(userId) + "\n" + e.message;
+        _lastError = l.errorAuthorizationFailed(userId);
+        _lastErrorDetails = e.message;
         _loading = false;
       });
     } catch (e) {
       setState(() {
-        _lastError = e.toString();
+        _lastError = l.errorUnexpectedNetworkError;
+        _lastErrorDetails = e.toString();
         _loading = false;
       });
     }

--- a/lib/sign_in_page.dart
+++ b/lib/sign_in_page.dart
@@ -256,6 +256,11 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
         _lastError = l.errorSignInTimeout;
         _loading = false;
       });
+    } on InvalidAPIException {
+      setState(() {
+        _lastError = l.errorSignInNoHost;
+        _loading = false;
+      });
     } catch (e) {
       setState(() {
         _lastError = e.toString();

--- a/lib/sign_in_page.dart
+++ b/lib/sign_in_page.dart
@@ -256,9 +256,9 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
         _lastError = l.errorSignInTimeout;
         _loading = false;
       });
-    } on AuthorizationFailedException {
+    } on AuthorizationFailedException catch (e) {
       setState(() {
-        _lastError = l.errorAuthorizationFailed(userId);
+        _lastError = l.errorAuthorizationFailed(userId) + "\n" + e.message;
         _loading = false;
       });
     } catch (e) {

--- a/lib/sign_in_page.dart
+++ b/lib/sign_in_page.dart
@@ -256,7 +256,7 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
         _lastError = l.errorSignInTimeout;
         _loading = false;
       });
-    } on InvalidAPIException {
+    } on AuthorizationFailedException {
       setState(() {
         _lastError = l.errorAuthorizationFailed(userId);
         _loading = false;

--- a/lib/sign_in_page.dart
+++ b/lib/sign_in_page.dart
@@ -258,7 +258,7 @@ class _SignInPageState extends State<SignInPage> with StateLocalizationHelpers {
       });
     } on InvalidAPIException {
       setState(() {
-        _lastError = l.errorInvalidAPI;
+        _lastError = l.errorAuthorizationFailed(userId);
         _loading = false;
       });
     } catch (e) {

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -323,6 +323,6 @@ class InvalidSessionError implements Exception {
 }
 
 class AuthorizationFailedException implements Exception {
-  InvalidAPIException(this.message);
+  AuthorizationFailedException(this.message);
   final String message;
 }

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -119,6 +119,7 @@ class AppAuth {
         throw InvalidAPIException(e.message);
       }
 
+      // our session is probably not worth anything anymore, destroy it
       await _destroyCurrentSession("Failed to fetch access token: ${e.message}");
       return null; // Previous always raises
 

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -109,13 +109,17 @@ class AppAuth {
       return tokens["accessToken"];
     } on PlatformException catch (e) {
 
-      if (e.code.startsWith("timeout")) {
+      if (e.code.startsWith("timeout_")) {
         throw TimeoutException(e.message);
       }
 
       if (e.code.startsWith("failed_")) {
         // Catches all failed_discovery (Unknown service/API), failed_register, failed_auth. etc
-        throw AuthorizationFailedException(e.message);
+        throw AuthorizationFailedException(e.code, e.message);
+      }
+
+      if (e.message?.toLowerCase()?.contains("network") == true) {
+        throw e.message; // probably bad network
       }
 
       // our session is probably not worth anything anymore, destroy it
@@ -322,6 +326,7 @@ class InvalidSessionError implements Exception {
 }
 
 class AuthorizationFailedException implements Exception {
-  AuthorizationFailedException(this.message);
+  AuthorizationFailedException(this.code, this.message);
+  final String code;
   final String message;
 }

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -109,7 +109,6 @@ class AppAuth {
       return tokens["accessToken"];
     } on PlatformException catch (e) {
 
-      // Check code before message
       if (e.code.startsWith("timeout")) {
         throw TimeoutException(e.message);
       }

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -113,7 +113,15 @@ class AppAuth {
       if (e.code.startsWith("timeout")) {
         throw TimeoutException(e.message);
       }
-      throw InvalidAPIException(e.message);
+
+      if (e.code.startsWith("failed_")) {
+        // Catches all failed_discovery (Unknown service/API), failed_register, failed_auth. etc
+        throw InvalidAPIException(e.message);
+      }
+
+      await _destroyCurrentSession("Failed to fetch access token: ${e.message}");
+      return null; // Previous always raises
+
     }
   }
 
@@ -314,9 +322,6 @@ class InvalidSessionError implements Exception {
   String toString() => "Invalid session: $message";
 }
 
-/**
- * API is invalid
- */
 class InvalidAPIException implements Exception {
   InvalidAPIException(this.message);
   final String message;

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -115,7 +115,7 @@ class AppAuth {
 
       if (e.code.startsWith("failed_")) {
         // Catches all failed_discovery (Unknown service/API), failed_register, failed_auth. etc
-        throw InvalidAPIException(e.message);
+        throw AuthorizationFailedException(e.message);
       }
 
       // our session is probably not worth anything anymore, destroy it

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -322,7 +322,7 @@ class InvalidSessionError implements Exception {
   String toString() => "Invalid session: $message";
 }
 
-class InvalidAPIException implements Exception {
+class AuthorizationFailedException implements Exception {
   InvalidAPIException(this.message);
   final String message;
 }

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -122,7 +122,6 @@ class AppAuth {
       // our session is probably not worth anything anymore, destroy it
       await _destroyCurrentSession("Failed to fetch access token: ${e.message}");
       return null; // Previous always raises
-
     }
   }
 

--- a/lib/src/app_auth.dart
+++ b/lib/src/app_auth.dart
@@ -108,17 +108,12 @@ class AppAuth {
 
       return tokens["accessToken"];
     } on PlatformException catch (e) {
-      if (e.message?.toLowerCase()?.contains("network") == true) {
-        throw e.message; // probably bad network
-      }
 
+      // Check code before message
       if (e.code.startsWith("timeout")) {
         throw TimeoutException(e.message);
       }
-
-      // our session is probably not worth anything anymore, destroy it
-      await _destroyCurrentSession("Failed to fetch access token: ${e.message}");
-      return null; // Previous always raises
+      throw InvalidAPIException(e.message);
     }
   }
 
@@ -317,4 +312,12 @@ class InvalidSessionError implements Exception {
 
   @override
   String toString() => "Invalid session: $message";
+}
+
+/**
+ * API is invalid
+ */
+class InvalidAPIException implements Exception {
+  InvalidAPIException(this.message);
+  final String message;
 }

--- a/lib/src/localizations.dart
+++ b/lib/src/localizations.dart
@@ -156,6 +156,13 @@ class InsporationLocalizations {
     locale: localeName
   );
 
+  String get errorSignInNoHost => Intl.message(
+      'Unable to resolve host, are you sure this pod supports the API?',
+      name: 'errorSignInNoHost',
+      desc: 'Error message if no host can not be resolved',
+      locale: localeName
+  );
+
   String deleteSessionPrompt(String userId) => Intl.message(
     'Remove session for $userId from insporation*?',
     name: 'deleteSessionPrompt',

--- a/lib/src/localizations.dart
+++ b/lib/src/localizations.dart
@@ -156,7 +156,7 @@ class InsporationLocalizations {
     locale: localeName
   );
 
-  String get errorInvalidAPI => Intl.message(
+  String errorAuthorizationFailed(String user) => Intl.message(
       'Service did not respond as expected. Is the hostname right? Does the pod run at least version 0.8?',
       name: 'errorInvalidAPI',
       desc: 'Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher',

--- a/lib/src/localizations.dart
+++ b/lib/src/localizations.dart
@@ -159,7 +159,7 @@ class InsporationLocalizations {
   String errorAuthorizationFailed(String user) => Intl.message(
       'Could not authorize to $user, is it spelled correctly, is your network running and is your pod running the latest development snapshot?', // TODO update message after diaspora 0.8 release
       name: 'errorInvalidAPI',
-      desc: 'Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher',
+      desc: 'Error message after authorization with the host failed',
       locale: localeName
   );
 

--- a/lib/src/localizations.dart
+++ b/lib/src/localizations.dart
@@ -156,10 +156,18 @@ class InsporationLocalizations {
     locale: localeName
   );
 
-  String errorAuthorizationFailed(String user) => Intl.message(
-      'Could not authorize to $user, is it spelled correctly, is your network running and is your pod running the latest development snapshot?', // TODO update message after diaspora 0.8 release
-      name: 'errorInvalidAPI',
+  String errorAuthorizationFailed(String userId) => Intl.message(
+      'Could not authorize to $userId, is it spelled correctly, is your network running and is your pod running the latest development snapshot?', // TODO update message after diaspora 0.8 release
+      args: [userId],
+      name: 'errorAuthorizationFailed',
       desc: 'Error message after authorization with the host failed',
+      locale: localeName
+  );
+
+  String get errorUnexpectedNetworkError => Intl.message(
+      'A unexpected network error occurred',
+      name: 'errorUnexpectedNetworkError',
+      desc: 'A unspecified network error occurred',
       locale: localeName
   );
 

--- a/lib/src/localizations.dart
+++ b/lib/src/localizations.dart
@@ -156,10 +156,10 @@ class InsporationLocalizations {
     locale: localeName
   );
 
-  String get errorSignInNoHost => Intl.message(
-      'Unable to resolve host, are you sure this pod supports the API?',
-      name: 'errorSignInNoHost',
-      desc: 'Error message if no host can not be resolved',
+  String get errorInvalidAPI => Intl.message(
+      'Service did not respond as expected. Is the hostname right? Does the pod run at least version 0.8?',
+      name: 'errorInvalidAPI',
+      desc: 'Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher',
       locale: localeName
   );
 

--- a/lib/src/localizations.dart
+++ b/lib/src/localizations.dart
@@ -157,7 +157,7 @@ class InsporationLocalizations {
   );
 
   String errorAuthorizationFailed(String user) => Intl.message(
-      'Service did not respond as expected. Is the hostname right? Does the pod run at least version 0.8?',
+      'Could not authorize to $user, is it spelled correctly, is your network running and is your pod running the latest development snapshot?', // TODO update message after diaspora 0.8 release
       name: 'errorInvalidAPI',
       desc: 'Error message host did not respond. Either invalid hostname or pod run does not at least on version 0.8 or higher',
       locale: localeName

--- a/lib/src/widgets.dart
+++ b/lib/src/widgets.dart
@@ -9,7 +9,7 @@ import 'client.dart';
 import 'colors.dart' as colors;
 
 class ErrorMessage extends StatelessWidget {
-  const ErrorMessage(this.message, {Key key, this.onRetry}) : super(key: key);
+  const ErrorMessage(this.message, {String errorDetails, Key key, this.onRetry}) : super(key: key);
 
   final String message;
   final Function onRetry;


### PR DESCRIPTION
Changed technical messages to generic message.
In iOS case it could be possible, that Main view occured, but with a error

Changed from 
<img width="375" alt="Bildschirmfoto 2020-11-06 um 18 27 40" src="https://user-images.githubusercontent.com/501326/98404036-2c7ddb80-206a-11eb-8d70-ced1456504dd.png">

To: 
<img width="375" alt="Bildschirmfoto 2020-11-06 um 19 33 57" src="https://user-images.githubusercontent.com/501326/98404053-33a4e980-206a-11eb-9fd5-a0e8daaadcae.png">
