### PR TITLE
Added platform Share-Button

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -18,6 +18,8 @@ PODS:
     - Flutter
   - screen (0.0.1):
     - Flutter
+  - share (0.0.1):
+    - Flutter
   - shared_preferences (0.0.1):
     - Flutter
   - sqflite (0.0.1):
@@ -40,6 +42,7 @@ DEPENDENCIES:
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
   - screen (from `.symlinks/plugins/screen/ios`)
+  - share (from `.symlinks/plugins/share/ios`)
   - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
@@ -65,6 +68,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/path_provider/ios"
   screen:
     :path: ".symlinks/plugins/screen/ios"
+  share:
+    :path: ".symlinks/plugins/share/ios"
   shared_preferences:
     :path: ".symlinks/plugins/shared_preferences/ios"
   sqflite:
@@ -87,6 +92,7 @@ SPEC CHECKSUMS:
   image_picker: 9c3312491f862b28d21ecd8fdf0ee14e601b3f09
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
   screen: abd91ca7bf3426e1cc3646d27e9b2358d6bf07b0
+  share: 0b2c3e82132f5888bccca3351c504d0003b3b410
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
   sqflite: 4001a31ff81d210346b500c55b17f4d6c7589dd0
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef

--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -453,9 +453,7 @@ class _PostActionsViewState extends State<PostActionsView> with StateLocalizatio
     if (widget.post.public) {
       actions.add(
         IconButton(
-            icon: Icon(
-                (Platform.isIOS ? Icons.ios_share : Icons.share)
-            ),
+            icon: Icon(Platform.isIOS ? Icons.ios_share : Icons.share),
             onPressed: _sharePost
         ),
       );
@@ -610,9 +608,9 @@ class _PostActionsViewState extends State<PostActionsView> with StateLocalizatio
   _showOriginalPost() => Navigator.pushNamed(context, "/post", arguments: widget.post.root);
 
   _sharePost() {
-    Client client = context.read<Client>();
-    String hostname = client.currentUserId.split('@').last;
-    String guid = widget.post.guid;
+    final client = context.read<Client>(),
+      hostname = client.currentUserId.split('@').last,
+      guid = widget.post.guid;
     Share.share("https://$hostname/posts/$guid");
   }
 

--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -1,3 +1,5 @@
+import 'dart:io' show Platform;
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:carousel_slider/carousel_slider.dart';
 import 'package:expandable_widget/expandable.dart';
@@ -8,6 +10,7 @@ import 'package:flutter_html/style.dart';
 import 'package:flutter_slidable/flutter_slidable.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'package:share/share.dart';
 
 import 'client.dart';
 import 'comments.dart';
@@ -314,10 +317,25 @@ class _PostInteractionsViewState extends State<_PostInteractionsView> with State
             label: Text(widget.post.interactions.likes.toString()),
             textColor: colors.postInteractionIcon(theme),
             onPressed: _updatingLike || !widget.post.canLike ? null : _toggleLike
-          )
+          ),
+          FlatButton.icon(
+            icon: Icon(
+                (Platform.isIOS ? Icons.ios_share : Icons.share),
+                size: 16
+            ),
+            label: Text(""),
+            onPressed: _sharePost
+          ),
         ]
       ),
     );
+  }
+
+  _sharePost() {
+    Client client = context.read<Client>();
+    String hostname = client.currentUserId.split('@').last;
+    String guid = widget.post.guid;
+    Share.share("https://$hostname/posts/$guid", subject: truncateWithEllipsis(60, widget.post.body));
   }
 
   _toggleLike() async {
@@ -408,6 +426,7 @@ class _PostInteractionsViewState extends State<_PostInteractionsView> with State
       }
     }
   }
+
 }
 
 class PostActionsView extends StatefulWidget {

--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -318,24 +318,9 @@ class _PostInteractionsViewState extends State<_PostInteractionsView> with State
             textColor: colors.postInteractionIcon(theme),
             onPressed: _updatingLike || !widget.post.canLike ? null : _toggleLike
           ),
-          FlatButton.icon(
-            icon: Icon(
-                (Platform.isIOS ? Icons.ios_share : Icons.share),
-                size: 16
-            ),
-            label: Text(""),
-            onPressed: _sharePost
-          ),
         ]
       ),
     );
-  }
-
-  _sharePost() {
-    Client client = context.read<Client>();
-    String hostname = client.currentUserId.split('@').last;
-    String guid = widget.post.guid;
-    Share.share("https://$hostname/posts/$guid", subject: truncateWithEllipsis(60, widget.post.body));
   }
 
   _toggleLike() async {
@@ -426,7 +411,6 @@ class _PostInteractionsViewState extends State<_PostInteractionsView> with State
       }
     }
   }
-
 }
 
 class PostActionsView extends StatefulWidget {
@@ -466,6 +450,16 @@ class _PostActionsViewState extends State<PostActionsView> with StateLocalizatio
       actions.add(IconButton(icon: Icon(Icons.keyboard_return), onPressed: _showOriginalPost, tooltip: l.showOriginalPost));
     }
 
+    if (widget.post.public) {
+      actions.add(
+        IconButton(
+            icon: Icon(
+                (Platform.isIOS ? Icons.ios_share : Icons.share)
+            ),
+            onPressed: _sharePost
+        ),
+      );
+    }
     return widget.orientation ==  Axis.vertical ? Column(children: actions) : Row(mainAxisSize: MainAxisSize.min, children: actions);
   }
 
@@ -614,6 +608,14 @@ class _PostActionsViewState extends State<PostActionsView> with StateLocalizatio
   }
 
   _showOriginalPost() => Navigator.pushNamed(context, "/post", arguments: widget.post.root);
+
+  _sharePost() {
+    Client client = context.read<Client>();
+    String hostname = client.currentUserId.split('@').last;
+    String guid = widget.post.guid;
+    Share.share("https://$hostname/posts/$guid", subject: truncateWithEllipsis(60, widget.post.body));
+  }
+
 }
 
 class _PhotoSlider extends StatefulWidget {

--- a/lib/src/posts.dart
+++ b/lib/src/posts.dart
@@ -613,7 +613,7 @@ class _PostActionsViewState extends State<PostActionsView> with StateLocalizatio
     Client client = context.read<Client>();
     String hostname = client.currentUserId.split('@').last;
     String guid = widget.post.guid;
-    Share.share("https://$hostname/posts/$guid", subject: truncateWithEllipsis(60, widget.post.body));
+    Share.share("https://$hostname/posts/$guid");
   }
 
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -63,6 +63,12 @@ String _debugPrintError(String message, exception, stack) {
   return exceptionMessage;
 }
 
+String truncateWithEllipsis(int cutoff, String myString) {
+  return (myString.length <= cutoff)
+      ? myString
+      : '${myString.substring(0, cutoff)}...';
+}
+
 String formatErrorTrace(Exception exception, StackTrace stackTrace) {
   stackTrace = FlutterError.demangleStackTrace(stackTrace);
   Iterable<String> lines = stackTrace.toString().trimRight().split('\n');

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -63,12 +63,6 @@ String _debugPrintError(String message, exception, stack) {
   return exceptionMessage;
 }
 
-String truncateWithEllipsis(int cutoff, String myString) {
-  return (myString.length <= cutoff)
-      ? myString
-      : '${myString.substring(0, cutoff)}...';
-}
-
 String formatErrorTrace(Exception exception, StackTrace stackTrace) {
   stackTrace = FlutterError.demangleStackTrace(stackTrace);
   Iterable<String> lines = stackTrace.toString().trimRight().split('\n');

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -392,6 +392,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0-nullsafety.3"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.9.7"
   nested:
     dependency: transitive
     description:
@@ -560,6 +567,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.0.5"
+  share:
+    dependency: "direct main"
+    description:
+      name: share
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.5+4"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   geojson: ^0.9.1
   quiver: ^2.0.5
   expandable_widget: ^1.0.5
+  share: ^0.6.5+4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Solves #26 with platform-dependent Share Buttons: 

On iOS: 
<img width="411" alt="Bildschirmfoto 2020-11-19 um 12 53 54" src="https://user-images.githubusercontent.com/501326/99663194-861cd780-2a66-11eb-9a5f-3dd732cbd036.png">

<img width="433" alt="Bildschirmfoto 2020-11-19 um 12 47 07" src="https://user-images.githubusercontent.com/501326/99663138-71d8da80-2a66-11eb-86e4-af1a42dfa7c0.png">

On Android
<img width="368" alt="Bildschirmfoto 2020-11-19 um 12 56 24" src="https://user-images.githubusercontent.com/501326/99663296-a8aef080-2a66-11eb-982e-388d22151b86.png">

<img width="409" alt="Bildschirmfoto 2020-11-19 um 12 50 55" src="https://user-images.githubusercontent.com/501326/99662903-2b837b80-2a66-11eb-8677-2d9e789e98c4.png">


(on real device it looks much nicer)