### PR TITLE
Update deprecated auth call and references

### DIFF
--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,3 +1,5 @@
+*.p8
+devices.txt
 *.mode1v3
 *.mode2v3
 *.moved-aside

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -32,14 +32,13 @@ target 'Runner' do
   use_modular_headers!
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  pod 'AppAuth'
+  pod 'AppAuth', '~> 1.6'
 end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
   end
-  
   installer.pods_project.build_configurations.each do |config|
     config.build_settings["EXCLUDED_ARCHS[sdk=iphonesimulator*]"] = "arm64"
   end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - AppAuth (1.5.0):
-    - AppAuth/Core (= 1.5.0)
-    - AppAuth/ExternalUserAgent (= 1.5.0)
-  - AppAuth/Core (1.5.0)
-  - AppAuth/ExternalUserAgent (1.5.0):
+  - AppAuth (1.6.0):
+    - AppAuth/Core (= 1.6.0)
+    - AppAuth/ExternalUserAgent (= 1.6.0)
+  - AppAuth/Core (1.6.0)
+  - AppAuth/ExternalUserAgent (1.6.0):
     - AppAuth/Core
   - catcher (0.0.1):
     - Flutter
@@ -48,7 +48,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
-  - AppAuth
+  - AppAuth (~> 1.6)
   - catcher (from `.symlinks/plugins/catcher/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
@@ -113,13 +113,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/webview_flutter_wkwebview/ios"
 
 SPEC CHECKSUMS:
-  AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
+  AppAuth: 8fca6b5563a5baef2c04bee27538025e4ceb2add
   catcher: 67a006a3c121c4bbf1202d1e5ea186afb7ef4a18
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
   flutter_app_badger: b87fc231847b03b92ce1412aa351842e7e97932f
   flutter_mailer: 2ef5a67087bc8c6c4cefd04a178bf1ae2c94cd83
-  fluttertoast: 16fbe6039d06a763f3533670197d01fc73459037
+  fluttertoast: 74526702fea2c060ea55dde75895b7e1bde1c86b
   FMDB: 2ce00b547f966261cd18927a3ddb07cb6f3db82a
   image_crop: e0a67085d3ebf3cf46ca46d61c53a082507b0bc3
   image_native_resizer: 9f91c5cb7e4388d929f53bc44d2b834bd0e7fe22
@@ -135,6 +135,6 @@ SPEC CHECKSUMS:
   wakelock: d0fc7c864128eac40eba1617cb5264d9c940b46f
   webview_flutter_wkwebview: b7e70ef1ddded7e69c796c7390ee74180182971f
 
-PODFILE CHECKSUM: 522d5d7221f25980820dab83b1d8fb7a6d209803
+PODFILE CHECKSUM: 1d147b70c2856def91148e1a841b2f87c7dd67cd
 
 COCOAPODS: 1.11.3

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -668,8 +668,10 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CODE_SIGN_ENTITLEMENTS = "Insporation-Share/Insporation-Share.entitlements";
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = MYEC2JCSBB;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = MYEC2JCSBB;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				INFOPLIST_FILE = "Insporation-Share/Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 12.4;
@@ -678,12 +680,13 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "eu.jhass.insporation.Insporation-Share";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development insporation-share";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AdHoc eu.jhass.insporation.Insporation-Share";
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -712,7 +715,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "eu.jhass.insporation.Insporation-Share";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -743,7 +746,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.0.0;
+				MARKETING_VERSION = 1.1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = "eu.jhass.insporation.Insporation-Share";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -960,9 +963,11 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Runner.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				DEVELOPMENT_TEAM = MYEC2JCSBB;
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = MYEC2JCSBB;
 				ENABLE_BITCODE = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -981,6 +986,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = eu.jhass.insporation;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development eu.jhass.insporation";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "match AdHoc eu.jhass.insporation";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;

--- a/ios/Runner/AppAuthHandler.swift
+++ b/ios/Runner/AppAuthHandler.swift
@@ -340,9 +340,7 @@ extension AppAuthHandler {
         var data: Data? = nil
         
         if let authState = state {
-            // Attention! The archivedData method is marked as deprecated in iOS 12.0, but recommended method
-            // will not recover the OIDAuthState correctly
-            data = NSKeyedArchiver.archivedData(withRootObject: authState)
+            data = try? NSKeyedArchiver.archivedData(withRootObject: authState, requiringSecureCoding: true)
         }
         
         let userIdAuthKey = kAppAuthAuthStateKey + userId
@@ -361,7 +359,7 @@ extension AppAuthHandler {
         
         // Attention! The archivedData method is marked as deprecated, but recommended method
         // will not recover the OIDAuthState correctly
-        if let authState = NSKeyedUnarchiver.unarchiveObject(with: data) as? OIDAuthState {
+        if let authState = try? NSKeyedUnarchiver.unarchivedObject(ofClass: OIDAuthState.self, from: data) {
             self.setAuthState(authState)
             return authState
         }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -66,5 +66,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 </dict>
 </plist>

--- a/ios/fastlane/Fastfile
+++ b/ios/fastlane/Fastfile
@@ -16,8 +16,8 @@
 default_platform(:ios)
 
 platform :ios do
-  desc "Push a new beta build to TestFlight"
   lane :beta do
+    desc "Push a new beta build to TestFlight"
     if is_ci
       increment_build_number(build_number: ENV["GITHUB_RUN_NUMBER"] || "1")
       create_keychain(
@@ -60,5 +60,16 @@ platform :ios do
       changelog: "Latest nightly build changes",
       reject_build_waiting_for_review: true
     )
+  end
+  lane :certificate do
+    api_key = app_store_connect_api_key(
+      key_id: "5WH6QW742Y",
+      issuer_id: "69a6de86-40c8-47e3-e053-5b8c7c11a4d1",
+      key_filepath: "./AuthKey_5WH6QW742Y.p8",
+      duration: 1200,
+      in_house: false
+    )
+    register_devices(devices_file: "./devices.txt")
+    match(type: "adhoc", force_for_new_devices: true)
   end
 end

--- a/ios/fastlane/README.md
+++ b/ios/fastlane/README.md
@@ -1,29 +1,40 @@
 fastlane documentation
-================
+----
+
 # Installation
 
 Make sure you have the latest version of the Xcode command line tools installed:
 
-```
+```sh
 xcode-select --install
 ```
 
-Install _fastlane_ using
-```
-[sudo] gem install fastlane -NV
-```
-or alternatively using `brew install fastlane`
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
 
 # Available Actions
+
 ## iOS
+
 ### ios beta
+
+```sh
+[bundle exec] fastlane ios beta
 ```
-fastlane ios beta
+
+
+
+### ios certificate
+
+```sh
+[bundle exec] fastlane ios certificate
 ```
-Push a new beta build to TestFlight
+
+
 
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
-More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
The auth lib was updated by vendor to support finally the newer archive/unachive command. This fixes a deprecated warning. 
Some minor settings are auto-updated by Xcode.

A cert update is also imminent. The fastfile was prepared for this. 
