### PR TITLE
fix up Fastlane descriptions

### DIFF
--- a/metadata/en-US/full_description.txt
+++ b/metadata/en-US/full_description.txt
@@ -1,3 +1,3 @@
-A native [diaspora\*](https://diasporafoundation.org) client powered by Flutter.
+A native <a href='https://diasporafoundation.org'>diaspora*</a> client powered by Flutter.
 
 This is still in preview. You will need a pod on the latest develop branch. Contributions are welcome, please open an issue if you work on something bigger to avoid duplicated effort :)

--- a/metadata/en-US/short_description.txt
+++ b/metadata/en-US/short_description.txt
@@ -1,1 +1,1 @@
-A native [diaspora\*](https://diasporafoundation.org) client powered by Flutter.
+A native diaspora* client powered by Flutter.


### PR DESCRIPTION
This covers the first two bullet-points of #73 

* `short_description.txt` is now plain-text as per Fastlane specifications
* `full_description.txt` has the Markdown link converted to a HTML link, which again complies with the specs.